### PR TITLE
Lighten up the motor state-read loop

### DIFF
--- a/src/polydact/polydact/dynamixel_interface.py
+++ b/src/polydact/polydact/dynamixel_interface.py
@@ -22,7 +22,7 @@ ADDR_PRESENT_VELOCITY = 128
 PROTOCOL_VERSION = 2.0  # Default Protocol version of DYNAMIXEL X series.
 
 # Default settings
-BAUDRATE = 57600  # Dynamixel default baudrate : 57600
+BAUDRATE = 1000000  # Motors are configured for 1 Mbps
 DEVICE_NAME = '/dev/ttyUSB0'  # Check which port is being used on your controller
 
 TORQUE_ENABLE = 1  # Value for enabling the torque

--- a/src/polydact/polydact/dynamixel_interface.py
+++ b/src/polydact/polydact/dynamixel_interface.py
@@ -241,10 +241,6 @@ class DynamixelInterface:
                 f'Load Error: {self.packet_handler.getRxPacketError(dxl_error)}'
             )
         self.node.get_logger().debug(f'DYN: Motor {motor_id} current {current_effort}')
-        current_effort, dxl_comm_result, dxl_error = self.packet_handler.read2ByteTxRx(
-            self.port_handler, motor_id, ADDR_PRESENT_PWM
-        )
-        self.node.get_logger().debug(f'DYN: Motor {motor_id} pwm {current_effort}')
 
         return current_effort
 

--- a/src/polydact/polydact/motor_coordinator.py
+++ b/src/polydact/polydact/motor_coordinator.py
@@ -69,7 +69,9 @@ class MotorCoordinator(Node):
         self.velo_pub = self.create_publisher(MotorGoal, 'cur_velocity', 10)
         self.load_pub = self.create_publisher(MotorGoal, 'cur_load', 10)
 
-        self.timer = self.create_timer(1 / 100, self.timer_callback)
+        # State reads are blocking serial round-trips; at 100 Hz they saturate the
+        # bus and starve the command path. 20 Hz is plenty for telemetry.
+        self.timer = self.create_timer(1 / 20, self.timer_callback)
         self.get_logger().info(f'motors: {self.motors.keys()}')
         for motor in self.motors.values():
             motor.set_mode(1)

--- a/src/polydact/polydact/serial_sensor_node.py
+++ b/src/polydact/polydact/serial_sensor_node.py
@@ -64,7 +64,7 @@ class SerialReader(Node):
 
         self.reading_timer = self.create_timer(1 / read_freq, self.reading_timer_callback)
         self.publishing_timer = self.create_timer(
-            int(1 / self.pub_freq), self.publishing_timer_callback
+            1 / self.pub_freq, self.publishing_timer_callback
         )
         self.get_logger().info('Serial Reader fully initialized')
 


### PR DESCRIPTION
Lightening up the motor state-read loop so it stops crowding out the velocity commands.

- Dropped the state-read timer from 100 Hz to 20 Hz. Plenty for telemetry, and it frees up the bus for actual commands.
- Removed the second read in `read_effort` - it read present current then overwrote it with present PWM, so it was doing two round-trips but only returning PWM. Now it just reads current once.
- Set the baudrate to 1 Mbps in code to match how the motors are configured (was hardcoded to 57600).
- Fix publishing timer period truncated to zero by int(), was calling publishing_timer_callback on ever spin, as fast as CPU can go